### PR TITLE
Refactors Logging feature

### DIFF
--- a/OSLoader/OSLoader/Logger.cs
+++ b/OSLoader/OSLoader/Logger.cs
@@ -5,140 +5,141 @@ using System.IO;
 using UnityEngine;
 using Newtonsoft.Json;
 
-namespace OSLoader
+
+//Its best practice to use file-scoped namespaces
+namespace OSLoader;
+
+public class Logger
 {
-    public class Logger
+    private readonly string name;
+    private readonly bool logToLoaderLog;
+    private readonly bool logTimestamps;
+    private const string loaderFileFilepath = @"./loader.log";
+
+    //This creates a single stream instance that manages all logging
+    //Rather than rely on File.WriteAllText which creates and destroys
+    //Streams each time you call it
+    private readonly static TextWriter _logOutput = new StreamWriter(loaderFileFilepath, false)
     {
-        private readonly string name;
-        private readonly bool logToLoaderLog;
-        private readonly bool logTimestamps;
-        private const string loaderFileFilepath = @"./loader.log";
+        AutoFlush = true
+    };
 
-        //This creates a single stream instance that manages all logging
-        //Rather than rely on File.WriteAllText which creates and destroys
-        //Streams each time you call it
-        private readonly static TextWriter _logOutput = new StreamWriter(loaderFileFilepath, false)
+    public bool logDetails = false;
+
+    public Logger(string name, bool logToLoaderLog = false, bool logDetails = false, bool logTimestamps = true)
+    {
+        this.name = name;
+        this.logToLoaderLog = logToLoaderLog;
+        this.logDetails = logDetails;
+        this.logTimestamps = logTimestamps;
+    }
+
+    public static void Initialize()
+    {
+        // Since we set append to false in the writer we can
+        // simply begin writing and it will clear for us
+
+        _logOutput.WriteLine("[OS Loader] Logger initialized");
+    }
+
+    // This feels like a bad idea. There is a verbose and normal
+    // Version of doorstop so if the user has these logs its because
+    // The chose to install verbose and you shouldn't touch them imo
+    public static void DeleteDoorstopLog()
+    {
+        string[] files = Directory.GetFiles("./", "*.log");
+        foreach (string file in files)
         {
-            AutoFlush = true
-        };
-
-        public bool logDetails = false;
-
-        public Logger(string name, bool logToLoaderLog = false, bool logDetails = false, bool logTimestamps = true)
-        {
-            this.name = name;
-            this.logToLoaderLog = logToLoaderLog;
-            this.logDetails = logDetails;
-            this.logTimestamps = logTimestamps;
-        }
-
-        public static void Initialize()
-        {
-            // Since we set append to false in the writer we can
-            // simply begin writing and it will clear for us
-
-            _logOutput.WriteLine("[OS Loader] Logger initialized");
-        }
-
-        // This feels like a bad idea. There is a verbose and normal
-        // Version of doorstop so if the user has these logs its because
-        // The chose to install verbose and you shouldn't touch them imo
-        public static void DeleteDoorstopLog()
-        {
-            string[] files = Directory.GetFiles("./", "*.log");
-            foreach (string file in files)
+            if (file.ToLower().Contains("doorstop_"))
             {
-                if (file.ToLower().Contains("doorstop_"))
+                Loader.Instance.logger.Log("Deleting doorstop log file with path " + file);
+                try
                 {
-                    Loader.Instance.logger.Log("Deleting doorstop log file with path " + file);
-                    try
-                    {
-                        File.Delete(file);
-                    }
-                    catch // (Exception e)
-                    {
-                        // This actually comes in handy, we don't delete the last one (Shared File Exception)
-                        // Loader.Instance.logger.Log("Could not delete Doorstop log file: " + e);
-                    }
+                    File.Delete(file);
+                }
+                catch // (Exception e)
+                {
+                    // This actually comes in handy, we don't delete the last one (Shared File Exception)
+                    // Loader.Instance.logger.Log("Could not delete Doorstop log file: " + e);
                 }
             }
         }
+    }
 
-        public void Log(object obj)
-        {
-            Log(obj.ToString());
-        }
+    public void Log(object obj)
+    {
+        Log(obj.ToString());
+    }
 
-        public void Log(string message)
-        {
-            string log = "";
-            if (logTimestamps)
-                log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
+    public void Log(string message)
+    {
+        string log = "";
+        if (logTimestamps)
+            log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
 
-            log += $"[{name}] [INFO] {message}";
-            if (logToLoaderLog)
-                _logOutput.WriteLine(log);
+        log += $"[{name}] [INFO] {message}";
+        if (logToLoaderLog)
+            _logOutput.WriteLine(log);
 
-            if (Loader.Instance.ModloaderInitialized)
-                Debug.Log(log);
-        }
+        if (Loader.Instance.ModloaderInitialized)
+            Debug.Log(log);
+    }
 
-        public void Detail(object obj) =>
-        //{
-        // The previous code here feels like a bug so I "fixed" it
-        // For ya, buddy.
+    public void Detail(object obj) =>
+    //{
+    // The previous code here feels like a bug so I "fixed" it
+    // For ya, buddy.
 
-        //Log(obj.ToString());
-        Detail(obj.ToString());
+    //Log(obj.ToString());
+    Detail(obj.ToString());
 
-        // Also: Seriously consider using the inline form for these
-        // types of methods
-        // public void Detail(object obj) => Detail(obj.ToString())
-        // Would be a lot cleaner so I left this as an example for you
-        //}
+    // Also: Seriously consider using the inline form for these
+    // types of methods
+    // public void Detail(object obj) => Detail(obj.ToString())
+    // Would be a lot cleaner so I left this as an example for you
+    //}
 
-        public void Detail(string message)
-        {
-            if (!logDetails) return;
+    public void Detail(string message)
+    {
+        if (!logDetails) return;
 
-            string log = "";
-            if (logTimestamps)
-                log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
+        string log = "";
+        if (logTimestamps)
+            log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
 
-            log += $"[{name}] [DETAIL] {message}";
-            if (logToLoaderLog)
-                _logOutput.WriteLine(log);
+        log += $"[{name}] [DETAIL] {message}";
+        if (logToLoaderLog)
+            _logOutput.WriteLine(log);
 
-            if (Loader.Instance.ModloaderInitialized)
-                Debug.Log(log);
-        }
+        if (Loader.Instance.ModloaderInitialized)
+            Debug.Log(log);
+    }
 
-        public void Error(string message)
-        {
-            string log = "";
-            if (logTimestamps)
-                log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
+    public void Error(string message)
+    {
+        string log = "";
+        if (logTimestamps)
+            log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
 
-            log += $"[{name}] [ERROR] {message}";
-            if (logToLoaderLog)
-                _logOutput.WriteLine(log);
+        log += $"[{name}] [ERROR] {message}";
+        if (logToLoaderLog)
+            _logOutput.WriteLine(log);
 
-            if (Loader.Instance.ModloaderInitialized)
-                Debug.LogError(log);
-        }
+        if (Loader.Instance.ModloaderInitialized)
+            Debug.LogError(log);
+    }
 
-        public void Warn(string message)
-        {
-            string log = "";
-            if (logTimestamps)
-                log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
+    public void Warn(string message)
+    {
+        string log = "";
+        if (logTimestamps)
+            log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
 
-            log += $"[{name}] [WARN] {message}";
-            if (logToLoaderLog)
-                _logOutput.WriteLine(log);
+        log += $"[{name}] [WARN] {message}";
+        if (logToLoaderLog)
+            _logOutput.WriteLine(log);
 
-            if (Loader.Instance.ModloaderInitialized)
-                Debug.LogWarning(log);
-        }
+        if (Loader.Instance.ModloaderInitialized)
+            Debug.LogWarning(log);
     }
 }

--- a/OSLoader/OSLoader/Logger.cs
+++ b/OSLoader/OSLoader/Logger.cs
@@ -5,14 +5,22 @@ using System.IO;
 using UnityEngine;
 using Newtonsoft.Json;
 
-namespace OSLoader {
+namespace OSLoader
+{
     public class Logger
     {
         private readonly string name;
         private readonly bool logToLoaderLog;
         private readonly bool logTimestamps;
-
         private const string loaderFileFilepath = @"./loader.log";
+
+        //This creates a single stream instance that manages all logging
+        //Rather than rely on File.WriteAllText which creates and destroys
+        //Streams each time you call it
+        private readonly static TextWriter _logOutput = new StreamWriter(loaderFileFilepath, false)
+        {
+            AutoFlush = true
+        };
 
         public bool logDetails = false;
 
@@ -26,10 +34,15 @@ namespace OSLoader {
 
         public static void Initialize()
         {
-            // Wipe old file
-            File.WriteAllText(loaderFileFilepath, "[OS Loader] Logger initialized\n");
+            // Since we set append to false in the writer we can
+            // simply begin writing and it will clear for us
+
+            _logOutput.WriteLine("[OS Loader] Logger initialized");
         }
 
+        // This feels like a bad idea. There is a verbose and normal
+        // Version of doorstop so if the user has these logs its because
+        // The chose to install verbose and you shouldn't touch them imo
         public static void DeleteDoorstopLog()
         {
             string[] files = Directory.GetFiles("./", "*.log");
@@ -64,16 +77,25 @@ namespace OSLoader {
 
             log += $"[{name}] [INFO] {message}";
             if (logToLoaderLog)
-                File.AppendAllText(loaderFileFilepath, log + "\n");
+                _logOutput.WriteLine(log);
 
             if (Loader.Instance.ModloaderInitialized)
                 Debug.Log(log);
         }
 
-        public void Detail(object obj)
-        {
-            Log(obj.ToString());
-        }
+        public void Detail(object obj) =>
+        //{
+        // The previous code here feels like a bug so I "fixed" it
+        // For ya, buddy.
+
+        //Log(obj.ToString());
+        Detail(obj.ToString());
+
+        // Also: Seriously consider using the inline form for these
+        // types of methods
+        // public void Detail(object obj) => Detail(obj.ToString())
+        // Would be a lot cleaner so I left this as an example for you
+        //}
 
         public void Detail(string message)
         {
@@ -85,7 +107,7 @@ namespace OSLoader {
 
             log += $"[{name}] [DETAIL] {message}";
             if (logToLoaderLog)
-                File.AppendAllText(loaderFileFilepath, log + "\n");
+                _logOutput.WriteLine(log);
 
             if (Loader.Instance.ModloaderInitialized)
                 Debug.Log(log);
@@ -99,7 +121,7 @@ namespace OSLoader {
 
             log += $"[{name}] [ERROR] {message}";
             if (logToLoaderLog)
-                File.AppendAllText(loaderFileFilepath, log + "\n");
+                _logOutput.WriteLine(log);
 
             if (Loader.Instance.ModloaderInitialized)
                 Debug.LogError(log);
@@ -113,7 +135,7 @@ namespace OSLoader {
 
             log += $"[{name}] [WARN] {message}";
             if (logToLoaderLog)
-                File.AppendAllText(loaderFileFilepath, log + "\n");
+                _logOutput.WriteLine(log);
 
             if (Loader.Instance.ModloaderInitialized)
                 Debug.LogWarning(log);

--- a/OSLoader/OSLoader/Logger.cs
+++ b/OSLoader/OSLoader/Logger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
@@ -73,7 +73,7 @@ public class Logger
 
     public void Log(string message)
     {
-        string log = "";
+        string log = string.Empty;
         if (logTimestamps)
             log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
 
@@ -103,7 +103,7 @@ public class Logger
     {
         if (!logDetails) return;
 
-        string log = "";
+        string log = string.Empty;
         if (logTimestamps)
             log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
 
@@ -117,7 +117,7 @@ public class Logger
 
     public void Error(string message)
     {
-        string log = "";
+        string log = string.Empty;
         if (logTimestamps)
             log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
 
@@ -131,7 +131,7 @@ public class Logger
 
     public void Warn(string message)
     {
-        string log = "";
+        string log = string.Empty;
         if (logTimestamps)
             log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
 

--- a/OSLoader/OSLoader/Logger.cs
+++ b/OSLoader/OSLoader/Logger.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
@@ -66,6 +66,11 @@ public class Logger
         }
     }
 
+    protected string GetTimeStampString()
+    {
+        return $"{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fffZ}";
+    }
+
     public void Log(object obj)
     {
         Log(obj.ToString());
@@ -75,7 +80,7 @@ public class Logger
     {
         string log = string.Empty;
         if (logTimestamps)
-            log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
+            log = GetTimeStampString();
 
         log += $"[{name}] [INFO] {message}";
         if (logToLoaderLog)
@@ -105,7 +110,7 @@ public class Logger
 
         string log = string.Empty;
         if (logTimestamps)
-            log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
+            log = GetTimeStampString();
 
         log += $"[{name}] [DETAIL] {message}";
         if (logToLoaderLog)
@@ -119,7 +124,7 @@ public class Logger
     {
         string log = string.Empty;
         if (logTimestamps)
-            log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
+            log = GetTimeStampString();
 
         log += $"[{name}] [ERROR] {message}";
         if (logToLoaderLog)
@@ -133,7 +138,7 @@ public class Logger
     {
         string log = string.Empty;
         if (logTimestamps)
-            log += $"[{JsonConvert.SerializeObject(DateTime.Now, new JsonSerializerSettings { DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffZ" })}] ";
+            log = GetTimeStampString();
 
         log += $"[{name}] [WARN] {message}";
         if (logToLoaderLog)

--- a/OSLoader/OSLoader/OSLoader.csproj
+++ b/OSLoader/OSLoader/OSLoader.csproj
@@ -3,10 +3,18 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<LangVersion>Latest</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="UnityEngine.Modules" Version="2019.4.40">
+			<IncludeAssets>all</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>
@@ -25,15 +33,9 @@
 		<Reference Include="UnityEngine.UI">
 			<HintPath>..\..\Dependencies\UnityEngine.UI.dll</HintPath>
 		</Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\Dependencies\UnityEngine.IMGUIModule.dll</HintPath>
-    </Reference>
+		<Reference Include="UnityEngine.IMGUIModule">
+			<HintPath>..\..\Dependencies\UnityEngine.IMGUIModule.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy &quot;$(TargetPath)&quot; &quot;..\..\Dependencies\&quot;&#xD;&#xA;" />
-    <Exec Command="copy &quot;$(TargetPath)&quot; &quot;..\..\ProjectReferences\Assets\Dependencies\&quot;&#xD;&#xA;" />
-    <!-- Uncomment this and change the paths to something that makes sense for you to auotmate moving the built file. -->
-    <Exec Command="copy &quot;$(TargetPath)&quot; &quot;D:\steam library\steamapps\common\Obenseuer\OSLoader&quot;&#xD;&#xA;" />
-  </Target>
 </Project>

--- a/OSLoader/OSLoader/OSLoader.csproj
+++ b/OSLoader/OSLoader/OSLoader.csproj
@@ -11,13 +11,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="UnityEngine.Modules" Version="2019.4.40">
-			<IncludeAssets>all</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup>
 		<Reference Include="Unity.TextMeshPro">
 			<HintPath>..\..\Dependencies\Unity.TextMeshPro.dll</HintPath>
 		</Reference>
@@ -37,5 +30,15 @@
 			<HintPath>..\..\Dependencies\UnityEngine.IMGUIModule.dll</HintPath>
 		</Reference>
 	</ItemGroup>
+
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<Exec Command="copy &quot;$(TargetPath)&quot; &quot;..\..\Dependencies\&quot;&#xD;&#xA;" />
+		<Exec
+			Command="copy &quot;$(TargetPath)&quot; &quot;..\..\ProjectReferences\Assets\Dependencies\&quot;&#xD;&#xA;" />
+		<!-- Uncomment this and change the paths to something that makes sense for you to auotmate
+		moving the built file. -->
+		<Exec
+			Command="copy &quot;$(TargetPath)&quot; &quot;D:\steam library\steamapps\common\Obenseuer\OSLoader&quot;&#xD;&#xA;" />
+	</Target>
 
 </Project>


### PR DESCRIPTION
Adds the following features:

- Changes C# Lang version to `Latest`
- Changes the file to a file-scoped namespace for better readability
- Adds a reusable stream to save overhead on writes
- Replaces repeated calls to JsonConvert.SerializeObject with a simple reference to DateTime.Now with a format string

Suggestions:

- Reconsider deleting the doorstop logs, users opt in to those intentionally
- Reformat any small block body methods into method body methods for readability

Please Review:

- [x] Logger.cs line 99
  - I changed the line from Log() to Detail() because it appeared to be an error
- [x] Logger.cs line 48
  - Suggestion: Remove this method and do not delete files on the user's PC